### PR TITLE
Performance improvements

### DIFF
--- a/src/octordle_solver/generate_groups.py
+++ b/src/octordle_solver/generate_groups.py
@@ -187,9 +187,6 @@ def generate_true_feedback(guess: str, answer: str) -> list[int]:
     feedback = [PossibilityState.INCORRECT.value] * 5
     answer_chars: list[Union[None, str]] = list(answer)
 
-    # TODO: See if I can combine this into one pass
-    # TODO: Maybe this is the best way to do it, but this should be part of the filter function
-    # TODO: Chunking
     for i in range(5):
         if guess[i] == answer[i]:
             feedback[i] = PossibilityState.CORRECT.value

--- a/tests/test_generate_groups.py
+++ b/tests/test_generate_groups.py
@@ -4,6 +4,7 @@ from octordle_solver.generate_groups import (
     Group,
     Possibility,
     PossibilityState,
+    create_chunks,
     evaluate_game_state,
     generate_groups,
     generate_groups_real_possibilities_only,
@@ -158,3 +159,11 @@ def test_generate_true_feedback(guess, answer, expected):
 )
 def test_generate_groups_real_possibilities_only(given_word, remaining_words, expected):
     assert generate_groups_real_possibilities_only(given_word, remaining_words) == expected
+
+
+def test_create_chunks():
+    in_list = [f"{i:02d}" for i in range(23)]
+    chunks = list(create_chunks(in_list, 10))
+    assert chunks[0] == ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09"]
+    assert chunks[1] == ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
+    assert chunks[2] == ["20", "21", "22"]

--- a/tests/test_generate_groups.py
+++ b/tests/test_generate_groups.py
@@ -1,9 +1,13 @@
 import pytest
 
 from octordle_solver.generate_groups import (
+    Group,
     Possibility,
+    PossibilityState,
     evaluate_game_state,
     generate_groups,
+    generate_groups_real_possibilities_only,
+    generate_true_feedback,
 )
 
 
@@ -87,3 +91,70 @@ def test_evaluate_game_state(word, possibility, other_word, expected):
 )
 def test_generate_groups(word, remaining_words, expected):
     assert generate_groups(word, remaining_words) == expected
+
+
+class TestGroup:
+    def test_str(self):
+        group = Group(["ABCDE"], (0, 0, 0, 0, 0))
+
+        assert str(group) == "(0, 0, 0, 0, 0)\n\tABCDE"
+        assert bool(Group) is True
+
+    @pytest.mark.parametrize(
+        "words, possibility, expected",
+        [
+            [[], (0, 0, 0, 0, 0), False],
+            [["ABCDE"], (0, 0, 0, 0, 0), True],
+            [["ABCDE", "VWXYZ"], (0, 0, 0, 0, 0), True],
+        ],
+    )
+    def test_bool(self, words, possibility, expected):
+        assert bool(Group(words, possibility)) is expected
+
+    def test_eq(self):
+        group_1 = Group(["ABCDE"], (0, 0, 0, 0, 0))
+        group_2 = Group(["ABCDE"], (0, 0, 0, 0, 0))
+        assert group_1 == group_2
+
+        group_1 = Group(["ABCDE"], (0, 0, 0, 0, 1))
+        group_2 = Group(["ABCDE"], (0, 0, 0, 0, 0))
+        assert group_1 != group_2
+
+        group_1 = Group(["ABCDE"], (0, 0, 0, 0, 0))
+        group_2 = Group(["VWXYZ"], (0, 0, 0, 0, 0))
+        assert group_1 != group_2
+
+        assert group_1 != {"words": ["ABCDE"], "possibility": (0, 0, 0, 0, 0)}
+
+
+@pytest.mark.parametrize(
+    "guess, answer, expected",
+    [
+        ["ABCDE", "ABCDE", [0, 0, 0, 0, 0]],
+        ["ABCDE", "ABCED", [0, 0, 0, 1, 1]],
+        ["ABCDE", "ABCDZ", [0, 0, 0, 0, 2]],
+        ["ABCDE", "VWXYZ", [2, 2, 2, 2, 2]],
+        ["APPLE", "PPLAE", [1, 0, 1, 1, 0]],
+    ],
+)
+def test_generate_true_feedback(guess, answer, expected):
+    assert generate_true_feedback(guess, answer) == expected
+
+
+@pytest.mark.parametrize(
+    "given_word, remaining_words, expected",
+    [
+        ["ABCDE", [], []],
+        [
+            "ABCDE",
+            ["ABCDE", "ABCED", "EDCBA"],
+            [
+                Group(["ABCDE"], (0, 0, 0, 0, 0)),
+                Group(["ABCED"], (0, 0, 0, 1, 1)),
+                Group(["EDCBA"], (1, 1, 0, 1, 1)),
+            ],
+        ],
+    ],
+)
+def test_generate_groups_real_possibilities_only(given_word, remaining_words, expected):
+    assert generate_groups_real_possibilities_only(given_word, remaining_words) == expected


### PR DESCRIPTION
Instead of iterating over all possibilities when generating groups, only iterate over actual possible solutions. Also use chunking instead of 

This greatly improves performance, I used this test code
```python
import time

from octordle_solver.dictionary import Dictionary
from octordle_solver.generate_groups import (
    get_all_answer_possibilities,
)
from octordle_solver.solver import filter_words

if __name__ == "__main__":
    remaining_words = Dictionary().valid_answers.copy()
    correct_letters = ["", "", "", "", ""]
    misplaced_letters = [("E", 4)]
    incorrect_letters = ["C", "R", "A", "N"]
    remaining_words = filter_words(remaining_words, correct_letters, misplaced_letters, incorrect_letters)
    start_time = time.time()
    get_all_answer_possibilities(remaining_words)
    end_time = time.time()
    print(end_time - start_time)
```

Before the improvements, this took around 30 seconds to run, it now takes about 1.5 seconds.